### PR TITLE
Add Vercel rewrite configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/:path((?!.*\\.).*)",
+      "destination": "/:path.html"
+    }
+  ]
+}


### PR DESCRIPTION
Introduces vercel.json with a rewrite rule to map requests without file extensions to corresponding .html files. This helps serve static HTML files for clean URLs.