### PR TITLE
Update page title section in quem-somos.html

### DIFF
--- a/quem-somos.html
+++ b/quem-somos.html
@@ -82,13 +82,17 @@
         </div>
     </header>
 
-    <main class="pt-24">
+ <main class="pt-24">
+        <!-- ===== Título da Página (ATUALIZADO) ===== -->
+        <section class="bg-[#002b3e] py-12">
+            <div class="container mx-auto px-6 text-center">
+                <h1 class="text-3xl md:text-4xl font-bold text-white uppercase tracking-widest">Quem Somos</h1>
+            </div>
+        </section>
+
         <!-- ===== Secção "Quem Somos" ===== -->
         <section id="quem-somos" class="py-20 bg-white">
             <div class="container mx-auto px-6">
-                <div class="text-center mb-16">
-                    <h2 class="text-3xl md:text-4xl font-bold text-gray-800 uppercase tracking-widest">Quem Somos</h2>
-                </div>
                 <div class="flex flex-wrap md:flex-nowrap items-center gap-8 md:gap-16">
                     <!-- Coluna de Texto -->
                     <div class="w-full md:w-1/2 text-gray-600">


### PR DESCRIPTION
Moved the 'Quem Somos' page title to a new dedicated section with updated styling and removed the previous title from the main content area for improved layout and consistency.